### PR TITLE
Strict

### DIFF
--- a/action.php
+++ b/action.php
@@ -37,6 +37,13 @@ class action_plugin_abortlogin extends DokuWiki_Action_Plugin
               header("HTTP/1.0 403 Forbidden");           
               exit("<div style='text-align:center; padding-top:2em;'><h1>403: Login Forbidden</h1></div>");
       }
+      
+      
+       if( empty($u) && empty($p) && empty($_REQUEST['http_credentials']) && !empty($USERINFO) && !$this->is_allowed($allowed, $ip)){
+            header("HTTP/1.0 403 Forbidden");                   
+            exit("<div style='text-align:center; padding-top:2em;'><h1>403:  Login Required</h1></div>");
+      }   
+      
       if($test && isset($USERINFO) && in_array('admin', $USERINFO['grps'])) {         
           $tests = explode(',',$test);
           foreach ($tests as $test) {           

--- a/action.php
+++ b/action.php
@@ -40,8 +40,8 @@ class action_plugin_abortlogin extends DokuWiki_Action_Plugin
       
       
        if( empty($u) && empty($p) && empty($_REQUEST['http_credentials']) && !empty($USERINFO) && !$this->is_allowed($allowed, $ip)){
-            header("HTTP/1.0 403 Forbidden");                   
-            exit("<div style='text-align:center; padding-top:2em;'><h1>403:  Login Required</h1></div>");
+             unset($USERINFO) ;
+             global $ACT;  $ACT = 'logout';          
       }   
       
       if($test && isset($USERINFO) && in_array('admin', $USERINFO['grps'])) {         


### PR DESCRIPTION
Removes reversion to logon dialog when  calling a page for which the access authorization for @ALL is set to None , enabling attacker with stolen credentials to login.